### PR TITLE
Call `notCompatibleWithConfigurationCache` when task doesn't support …

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -531,4 +531,22 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
         engine.addDependency(dependency)
     }
+
+    /**
+     * Check if the notCompatibleWithConfigurationCache method exists in the class.
+     * @return true if it exists; false otherwise.
+     */
+    protected boolean hasNotCompatibleWithConfigurationCacheOption() {
+        return metaClass.respondsTo(this, "notCompatibleWithConfigurationCache", String)
+    }
+
+    /**
+     * Calls notCompatibleWithConfigurationCache method in order to avoid failures when
+     * Gradle configuration cache is enabled.
+     */
+    protected void callIncompatibleWithConfigurationCache() {
+        String methodName = "notCompatibleWithConfigurationCache"
+        Object[] methodArgs = ["The gradle-versions-plugin isn't compatible with the configuration cache"]
+        metaClass.invokeMethod(this, methodName, methodArgs)
+    }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -29,6 +29,10 @@ class Aggregate extends AbstractAnalyze {
     Aggregate() {
         group = 'OWASP dependency-check'
         description = 'Identifies and reports known vulnerabilities (CVEs) in multi-project dependencies.'
+
+        if (hasNotCompatibleWithConfigurationCacheOption()) {
+            callIncompatibleWithConfigurationCache()
+        }
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -25,6 +25,10 @@ class Analyze extends AbstractAnalyze {
     Analyze() {
         group = 'OWASP dependency-check'
         description = 'Identifies and reports known vulnerabilities (CVEs) in project dependencies.'
+
+        if (hasNotCompatibleWithConfigurationCacheOption()) {
+            callIncompatibleWithConfigurationCache()
+        }
     }
 
     /**

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -69,4 +69,39 @@ class DependencyCheckPluginIntegSpec extends Specification {
         then:
         result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
     }
+
+    def "task completes successfully when configuration cache is enabled in Gradle 7.4"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.owasp.dependencycheck'
+            }
+            apply plugin: 'java'
+            
+            sourceCompatibility = 1.5
+            version = '1.0'
+            
+            repositories {
+                mavenLocal()
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation group: 'commons-collections', name: 'commons-collections', version: '3.2'
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withGradleVersion("7.4")
+                .withProjectDir(testProjectDir.root)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK, "--configuration-cache")
+                .withPluginClasspath()
+                .withDebug(true)
+                .forwardOutput()
+                .build()
+
+        then:
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
+    }
 }


### PR DESCRIPTION
…Gradle configuration cache